### PR TITLE
feat(profiles): add seller profile endpoints

### DIFF
--- a/backend/accounts/admin.py
+++ b/backend/accounts/admin.py
@@ -1,7 +1,14 @@
 from django.contrib import admin
-from .models import User
+from .models import User, SellerAccount
 
 
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):
     list_display = ("email", "first_name", "last_name", "role", "is_active")
+
+
+@admin.register(SellerAccount)
+class SellerAccountAdmin(admin.ModelAdmin):
+    list_display = ("user", "company_name", "verified", "account_status")
+    list_filter = ("verified", "account_status")
+    search_fields = ("company_name", "user__email")

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -51,6 +51,12 @@ class RegisterSerializer(serializers.ModelSerializer):
             )
         return value
 
+    def validate_role(self, value):
+        valid_roles = ["customer", "seller", "shipping_company"]
+        if value not in valid_roles:
+            raise serializers.ValidationError("Invalid role selected.")
+        return value
+
     def validate(self, attrs):
         if attrs["password"] != attrs["confirm_password"]:
             raise serializers.ValidationError("Passwords should match.")
@@ -107,3 +113,66 @@ class MyTokenRefreshSerializer(TokenRefreshSerializer):
         attrs["refresh"] = refresh
 
         return super().validate(attrs)
+
+
+class SellerAccountSerializer(serializers.ModelSerializer):
+    user_email = serializers.EmailField(source="user.email")
+    user_first_name = serializers.CharField(source="user.first_name")
+    user_last_name = serializers.CharField(source="user.last_name")
+    user_phone_number = serializers.CharField(source="user.phone_number")
+
+    class Meta:
+        model = SellerAccount
+        fields = [
+            "user_email",
+            "user_first_name",
+            "user_last_name",
+            "user_phone_number",
+            "company_name",
+            "business_license",
+            "tax_id",
+            "verified",
+            "account_status",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "verified",
+            "account_status",
+            "created_at",
+            "updated_at",
+        ]
+
+    def validate(self, attrs):
+        request = self.context.get("request")
+        user = request.user if request else None
+
+        if not user or not user.is_authenticated:
+            raise serializers.ValidationError("Authentication is required.")
+
+        if user.role != "seller":
+            raise serializers.ValidationError(
+                (
+                    "Only users with the 'seller' "
+                    "role can create a seller account."
+                )
+            )
+
+        if (
+            self.instance is None
+            and SellerAccount.objects.filter(user=user).exists()
+        ):
+            raise serializers.ValidationError(
+                "You already have a seller account."
+            )
+
+        return attrs
+
+    def create(self, validated_data):
+        user = self.context["request"].user
+        return SellerAccount.objects.create(user=user, **validated_data)
+
+    def update(self, instance, validated_data):
+        validated_data.pop("verified", None)
+        validated_data.pop("account_status", None)
+        return super().update(instance, validated_data)

--- a/backend/accounts/tests/conftest.py
+++ b/backend/accounts/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def client():
+    return APIClient()

--- a/backend/accounts/tests/test_seller_workflow.py
+++ b/backend/accounts/tests/test_seller_workflow.py
@@ -1,0 +1,139 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from accounts.models import User, SellerAccount
+
+
+@pytest.mark.django_db
+class TestSellerWorkflow:
+
+    @pytest.fixture
+    def register_url(self):
+        return reverse("register")
+
+    @pytest.fixture
+    def seller_user_data(self):
+        return {
+            "email": "ahmed@gmail.com",
+            "first_name": "Ahmed",
+            "last_name": "Ramadan",
+            "role": "seller",
+            "password": "ahmed_Ramadan@123",
+            "confirm_password": "ahmed_Ramadan@123",
+        }
+
+    def test_register_seller_success(
+        self, client, register_url, seller_user_data
+    ):
+        # Checks successful creation response
+        response = client.post(register_url, seller_user_data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Checks user creation in the database
+        user = User.objects.get(email=seller_user_data["email"])
+        assert user.role == "seller"
+
+        # Checks seller profile creation in the database
+        seller_profile = SellerAccount.objects.get(user=user)
+        assert seller_profile.company_name == ""
+        assert seller_profile.business_license == ""
+        assert seller_profile.tax_id == ""
+        assert seller_profile.account_status == "pending"
+        assert seller_profile.verified is False
+
+    def test_register_seller_fails_existing_email(
+        self, client, register_url, seller_user_data
+    ):
+        user_data = dict()
+        for key, val in seller_user_data.items():
+            if key in ["email", "first_name", "last_name", "role", "password"]:
+                user_data[key] = val
+        User.objects.create(**user_data)
+
+        response = client.post(register_url, seller_user_data, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "email" in response.data
+
+    def test_register_seller_fails_invalid_password(
+        self, client, register_url, seller_user_data
+    ):
+        seller_user_data["password"] = "weak"
+        seller_user_data["confirm_password"] = "weak"
+
+        response = client.post(register_url, seller_user_data, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "password" in response.data
+
+    def test_register_seller_fails_invalid_role(
+        self, client, register_url, seller_user_data
+    ):
+        seller_user_data["role"] = "invalid_role"
+
+        response = client.post(register_url, seller_user_data, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "role" in response.data
+
+    def test_seller_profile_retrieve_success(self, client, django_user_model):
+        user = django_user_model.objects.create_user(
+            email="ahmed@gmail.com",
+            first_name="Ahmed",
+            last_name="Ramadan",
+            role="seller",
+            password="ahmed_Ramadan@123",
+            phone_number="0123456789",
+        )
+
+        # Creating a SellerAccount for the user
+        SellerAccount.objects.create(
+            user=user,
+            company_name="Chefco",
+            business_license="213451",
+            tax_id="34190321",
+        )
+
+        # Logging with the user's account in "seller" role
+        client.force_authenticate(user=user)
+        url = reverse("seller-me")
+
+        response = client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["company_name"] == "Chefco"
+        assert response.data["business_license"] == "213451"
+        assert response.data["tax_id"] == "34190321"
+
+    def test_seller_profile_update_success(self, client, django_user_model):
+        user = django_user_model.objects.create_user(
+            email="ahmed@gmail.com",
+            first_name="Ahmed",
+            last_name="Ramadan",
+            role="seller",
+            password="ahmed_Ramadan@123",
+            phone_number="0123456789",
+        )
+
+        # Creating a SellerAccount for the user
+        seller = SellerAccount.objects.create(
+            user=user,
+            company_name="Chefco",
+            business_license="213451",
+            tax_id="34190321",
+        )
+
+        client.force_authenticate(user=user)
+        url = reverse("seller-me")
+
+        # Updating allowed fields
+        response = client.patch(
+            url, {"company_name": "Italian Chef"}, format="json"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        seller.refresh_from_db()
+        assert seller.company_name == "Italian Chef"
+
+        # Updating restricted fields, which shouldn't change
+        response = client.patch(
+            url, {"verified": True, "account_status": "active"}, format="json"
+        )
+        seller.refresh_from_db()
+        assert seller.verified is False
+        assert seller.account_status == "pending"

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,11 +1,14 @@
 # accounts/urls.py
 from django.urls import path
 from rest_framework_simplejwt.views import TokenRefreshView
-from .views import RegisterView, MyTokenObtainPairView, LogoutView
+from . import views
 
 urlpatterns = [
-    path("register/", RegisterView.as_view()),
-    path("logout/", LogoutView.as_view()),
-    path("login/", MyTokenObtainPairView.as_view()),
-    path("refresh_token/", TokenRefreshView.as_view()),
+    path("auth/register/", views.RegisterView.as_view(), name="register"),
+    path("auth/logout/", views.LogoutView.as_view()),
+    path("auth/login/", views.MyTokenObtainPairView.as_view()),
+    path("auth/refresh_token/", TokenRefreshView.as_view()),
+    path(
+        "accounts/sellers/me", views.SellerMeView.as_view(), name="seller-me"
+    ),
 ]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -9,7 +9,10 @@ from .serializers import (
     RegisterSerializer,
     MyTokenObtainPairSerializer,
     MyTokenRefreshSerializer,
+    SellerAccountSerializer,
 )
+from .models import SellerAccount
+from rest_framework.exceptions import PermissionDenied, NotFound
 
 
 class RegisterView(generics.CreateAPIView):
@@ -84,3 +87,23 @@ class LogoutView(generics.GenericAPIView):
         )
         response.delete_cookie("refresh_token")
         return response
+
+
+class SellerMeView(generics.RetrieveUpdateAPIView):
+    serializer_class = SellerAccountSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_object(self):
+        user = self.request.user
+
+        if user.role != "seller":
+            raise PermissionDenied("Only sellers can access this endpoint.")
+
+        try:
+            return SellerAccount.objects.get(user=self.request.user)
+        except SellerAccount.DoesNotExist:
+            raise NotFound(detail="Seller account not found.")
+
+    def update(self, request, *args, **kwargs):
+        kwargs["partial"] = True
+        return super().update(request, *args, **kwargs)

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -6,6 +6,6 @@ from .views import hello_world
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("hello/", hello_world),
-    path("api/auth/", include("accounts.urls")),
+    path("api/", include("accounts.urls")),
     path("api/", include("addresses.urls")),
 ]


### PR DESCRIPTION
## 📌 Summary

<!-- What is this PR about? Why was it needed? Reference issue numbers if applicable. -->
Add GET & PATCH seller profile endpoints with Postman docs, integration tests, and role-based access controls.

## ✅ What Was Done

<!-- Brief description of major changes -->

- [x] Implemented GET & PATCH endpoints for seller profiles (company name, tax ID, etc.)
- [x] Documented endpoints in Postman
- [x] Added integration tests in pytest covering:
   - Seller registration workflow
   - Profile retrieval
   - Profile update
- [x] Applied role-based access checks to restrict to seller’s own profile

## 🧪 How to Test

<!-- How should a reviewer test this locally? Be as specific as possible -->

1. Run `sudo docker compose up --build`
2. Access the backend API documentation or Postman collection
3. Authenticate as a seller (register if needed)
4. Use the GET endpoint to retrieve your seller profile — confirm it returns correct details
5. Use the PATCH endpoint to update profile fields — confirm changes persist
6. Attempt access as a non-seller — confirm access is denied
7. Run tests: 
```bash
sudo docker compose exec backend pytest -k test_seller_workflow.py
```

## 🔁 Side Effects / Breaking Changes

<!-- Any potential side effects? DB changes? Backward compatibility issues? -->

- [ ] Database migration included
- [ ] Frontend state/API affected
- [ ] Breaking change to existing endpoint

## 📷 Screenshots

<!-- Add UI screenshots or terminal output if useful -->
**When a user without a "seller" role tries to access a seller-only endpoint, the backend raises an exception:**
<img width="1356" height="727" alt="Screenshot from 2025-08-09 14-44-27" src="https://github.com/user-attachments/assets/1f3b0d36-3527-4455-9124-6204644a6bf8" />
<img width="1356" height="727" alt="Screenshot from 2025-08-09 14-41-21" src="https://github.com/user-attachments/assets/36cfd7b9-7461-4abf-8f45-f3630e1f6042" />

**This is the user with "seller" role, when accessing `GET /sellers/me`:**
<img width="1356" height="727" alt="Screenshot from 2025-08-09 15-24-54" src="https://github.com/user-attachments/assets/a134a20c-61ee-4668-9cb3-29b3af3ada22" />

**This is the user with "seller" role, when accessing `PATCH /sellers/me`:**
<img width="1356" height="727" alt="Screenshot from 2025-08-09 14-40-43" src="https://github.com/user-attachments/assets/7c07aff8-db6d-4fdc-af34-9348092e7b6e" />

**Added Postman Variables (ACCESS_TOKEN, base_url), to use the access token across endpoints, and not repeat the `http://localhost:8000/` for more flexibility across different environments**
<img width="1356" height="286" alt="Screenshot from 2025-08-09 15-30-39" src="https://github.com/user-attachments/assets/bce25ba4-c7d3-401e-ab83-7c9695e02094" />


## 🔗 Related Issues

Partially addresses #10

## 📋 Checklist Before Merge

- [x] Code is self-documented and clean
- [x] Tests are added/updated
- [x] Docs/README updated if necessary
- [x] I rebased onto the latest `feature/profiles-products/seller` and resolved any conflicts
